### PR TITLE
Add attention mask to gamma coefficient calculation

### DIFF
--- a/train/mytrainer.py
+++ b/train/mytrainer.py
@@ -52,8 +52,8 @@ class KDTrainer(Trainer):
         forward_kl = F.kl_div(student_output_log_prob, teacher_output_soft, reduction="none").sum(-1)
 
         kl_loss = beta_prob * reverse_kl + (1 - beta_prob) * forward_kl
-        kl_loss *= mask
-        kl_loss = kl_loss.sum() / mask.sum()
+        kl_loss *= mask   # both kl_loss/mask have shape [batch, sequence_len]
+        kl_loss = kl_loss.sum(-1).mean()
         return kl_loss
 
     def jsd_loss(self, labels, student_logits, teacher_logits, beta_prob):

--- a/train/train.py
+++ b/train/train.py
@@ -373,7 +373,7 @@ def train():
             prob1 = torch.nn.functional.softmax(logits, dim=-1)
             prob1 = torch.max(prob1, dim=-1).values 
             mask = (batch["labels"] != -100)
-            prob1 *= mask
+            prob1 *= mask  # both prob1/mask have shape [batch_size, sequence_len]
             prob += prob1.sum() / mask.sum()
         mean_prob = prob / training_args.cakld_steps
         mean_prob = torch.Tensor(mean_prob.to(teacher_model.device))


### PR DESCRIPTION
Dry run: training/eval pipelines unaffected (dry run on 64 samples, and ppl/language benchmarks)

Compared both masked and unmasked gammas here https://github.com/BrownianNotion/BitDistiller/blob/gamma-mask-experiment/train/Gamma.txt

Conclusion
* masked gamma is consistently a few % lower than unmasked
* This is because of the way mask is calculated -> we are averaging over the same number of tokens but zeroing the probability of the pad tokens. This seems to mirror the mask used by the authors for the loss functions.
* However, perhaps this is not the correct implementation -> `prob1[mask].mean()` i.e. averaging over the non-zero probabilities may be more correct.