### PR TITLE
Fix weights_only error when loading model

### DIFF
--- a/inference/utils/load_quant.py
+++ b/inference/utils/load_quant.py
@@ -39,7 +39,7 @@ def mem_efficient_load_checkpoint(
     with tqdm(total=len(checkpoint_files)) as pbar:
         pbar.set_description("Loading checkpoint shards")
         for checkpoint_file in checkpoint_files:
-            checkpoint = torch.load(checkpoint_file, map_location=torch.device("cpu"))
+            checkpoint = torch.load(checkpoint_file, map_location=torch.device("cpu"), weights_only=True)
             model.load_state_dict(checkpoint, strict=False)
             # Force Python to clean up.
             del checkpoint
@@ -152,7 +152,7 @@ def load_awq_llama_fast(model, checkpoint, w_bit, group_size, device):
 
                 model.load_state_dict(safe_load(checkpoint))
             else:
-                model.load_state_dict(torch.load(checkpoint))
+                model.load_state_dict(torch.load(checkpoint, weights_only=True))
 
     # autotune_warmup(model)
 

--- a/train/train.py
+++ b/train/train.py
@@ -323,7 +323,7 @@ def train():
             "q_group_size": training_args.q_group_size,  # whether to use group quantization
         }
         print("Loading pre-computed Clipping results from", training_args.clip)
-        clip_results = torch.load(training_args.clip)
+        clip_results = torch.load(training_args.clip, weights_only=True)
         apply_clip(model, clip_results)
         print("Clipping init successfully!")
 


### PR DESCRIPTION
Weights only is fine here, we don't need the optimiser state.