### PR TITLE
Configs for 2bit baseline

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Our results is running by following 3 steps:
     cd train
     
 
-    bash train.sh ../data/datasets/tinyllama_v1.1/mix_wiki_alpaca_8000.json ./ckpts/tiny_llama_v1.1/int2-g128/ ./logs/tiny_llama_v1.1/int2-g128/ 1
+    bash train.sh ../data/datasets/tinyllama_v1.1/mix_wiki_alpaca_8000.json ./ckpts/tiny_llama_v1.1/int2-g128/ ./logs/tiny_llama_v1.1/int2-g128/ 4
     ```
 </details>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.37.0
+transformers==4.37.0  # REMOVE ONCE IN README: make sure vast uses cuda 12.4 or do pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121 as vast default is cuda 12.1, unlike lambda labs
 datasets
 evaluate
 deepspeed

--- a/train/train.sh
+++ b/train/train.sh
@@ -15,9 +15,9 @@ deepspeed --num_gpus=1 train.py \
     --num_train_epochs $4 \
     --bf16 True \
     --seed 42 \
-    --per_device_train_batch_size 4 \
-    --per_device_eval_batch_size 4 \
-    --gradient_accumulation_steps 1 \
+    --per_device_train_batch_size 16 \
+    --per_device_eval_batch_size 16 \
+    --gradient_accumulation_steps 4 \
     --gradient_checkpointing True \
     --evaluation_strategy "steps" \
     --eval_steps 4 \

--- a/train/train_dry_run.sh
+++ b/train/train_dry_run.sh
@@ -17,7 +17,7 @@ deepspeed --num_gpus=1 train.py \
     --seed 42 \
     --per_device_train_batch_size 16 \
     --per_device_eval_batch_size 16 \
-    --gradient_accumulation_steps 1 \
+    --gradient_accumulation_steps 4 \
     --gradient_checkpointing True \
     --evaluation_strategy "steps" \
     --eval_steps 4 \


### PR DESCRIPTION
Main change = changing batch size back to 16 to speed up training/match original authors. No out of memory errors for TinyLlama, unlike Qwen2.5-1.5B. We train for 4 epochs given the speed up (though 2-3 could also suffice based on the results). Use gradient accumulation steps of 4 for an effective batch size of 64.