### PR TITLE
Update eval steps

### DIFF
--- a/train/train.sh
+++ b/train/train.sh
@@ -20,11 +20,11 @@ deepspeed --num_gpus=1 train.py \
     --gradient_accumulation_steps 4 \
     --gradient_checkpointing True \
     --evaluation_strategy "steps" \
-    --eval_steps 4 \
+    --eval_steps 0.25 \
     --load_best_model_at_end True \
     --save_strategy "steps" \
-    --save_steps 20 \
-    --save_total_limit 3 \
+    --save_steps 500 \
+    --save_total_limit 1 \
     --learning_rate 2e-5 \
     --lr_scheduler_type "constant" \
     --weight_decay 0. \

--- a/train/train.sh
+++ b/train/train.sh
@@ -23,7 +23,7 @@ deepspeed --num_gpus=1 train.py \
     --eval_steps 0.25 \
     --load_best_model_at_end True \
     --save_strategy "steps" \
-    --save_steps 200 \
+    --save_steps 20 \
     --save_total_limit 3 \
     --learning_rate 2e-5 \
     --lr_scheduler_type "constant" \

--- a/train/train.sh
+++ b/train/train.sh
@@ -23,8 +23,8 @@ deepspeed --num_gpus=1 train.py \
     --eval_steps 0.25 \
     --load_best_model_at_end True \
     --save_strategy "steps" \
-    --save_steps 500 \
-    --save_total_limit 1 \
+    --save_steps 200 \
+    --save_total_limit 3 \
     --learning_rate 2e-5 \
     --lr_scheduler_type "constant" \
     --weight_decay 0. \


### PR DESCRIPTION
Lowered eval_steps from 4 to 0.25 to improve training efficiency. 
This helps reduce evaluation overhead and speeds up training.
Save steps now changed to 20 as before. 

Closes Issue #36 
