### PR TITLE
[Don't merge] Add PPL to eval logging

### DIFF
--- a/train/train.py
+++ b/train/train.py
@@ -26,6 +26,7 @@ import random
 from tqdm import tqdm
 
 import wandb
+import evaluate
 
 def _make_r_io_base(f, mode: str):
     if not isinstance(f, io.IOBase):
@@ -259,6 +260,10 @@ def make_supervised_data_module(tokenizer: transformers.PreTrainedTokenizer, dat
     data_collator = DataCollatorForSupervisedDataset(tokenizer=tokenizer)
     return dict(train_dataset=train_dataset, eval_dataset=eval_dataset, data_collator=data_collator)
 
+def compute_metrics(eval_preds):
+    metric = evaluate.load("perplexity", module_type="metric")
+    logits, labels = eval_preds
+    return metric.compute(predictions=logits, references=labels) 
 
 def train():
     # Parse command-line arguments for model, data, and training configurations
@@ -432,6 +437,7 @@ def train():
             loss_type=training_args.kd_loss_type, 
             mean_prob=mean_prob, 
             args=training_args, 
+            compute_metrics=compute_metrics,
             **data_module
         )
     else:
@@ -439,6 +445,7 @@ def train():
             model=model, 
             tokenizer=tokenizer, 
             args=training_args, 
+            compute_metrics=compute_metrics,
             **data_module
         )
     

--- a/train/train.sh
+++ b/train/train.sh
@@ -15,11 +15,12 @@ deepspeed --num_gpus=1 train.py \
     --bf16 True \
     --seed 42 \
     --per_device_train_batch_size 16 \
-    --per_device_eval_batch_size 16 \
+    --per_device_eval_batch_size 8 \
     --gradient_accumulation_steps 4 \
     --gradient_checkpointing True \
     --evaluation_strategy "steps" \
-    --eval_steps 40 \
+    --eval_steps 1 \
+    --eval_accumulation_steps 16 \
     --load_best_model_at_end True \
     --save_strategy "steps" \
     --save_steps 40 \


### PR DESCRIPTION
## Description  
<!-- Summary of the changes and the related issue number -->  
Add PPL to eval time logging. Currently bugged: https://wandb.ai/DeepFriedNLP/SNLP_BitDistiller/runs/8p8iykjy/logs

```
[rank0]: ValueError: Module inputs don't match the expected format.
146
2025-03-24 17:24:45
[rank0]: Expected format: {'predictions': Value(dtype='string', id=None)},
```

TODO:
- [x] rebase to wandb
- [x] Test on an instance
- [x] Confirm eval time impact (below)
- [ ] Fix bug
- [ ] Test settings on 80GB GPU

**eval time before:**  2:35
**eval time after:** 8:40 

(on A40, 45GB) see about a 3.4x increase + need to fix currently bugged implementation with format.
* Increase in eval time is mainly due to needing to lower `per_device_eval_batch_size` and `eval_accumulation_steps` to fit on the GPU. Possible that our settings on an 80GB means a smaller increase. 
* On an A100, eval takes about 1.5 min currently, so this change would take 2.4 * 1.5 * 10 = 36 min of extra training. 
* This is on the edge of being worth it for me. Perhaps can deprioritise this for now and focus on further experiments.

Closes #40 

## Pre-Merge Checklist  
- [X] I have included the issue number in my PR description  
- [X] I have rebased/pulled in changes from `main` and fixed any conflicts  
- [ ] If I have changed the models/training code, I have run `dry_run.sh` on a CUDA device successfully  